### PR TITLE
Error handling and syntax fixes

### DIFF
--- a/hangman-web/hangman.html
+++ b/hangman-web/hangman.html
@@ -4,7 +4,7 @@
   <title>Hangman Game</title>
   <style>
    .hangman-image {
-      /* Placeholder image link for hangman stick figures */
+      /* Placeholder image link for Hangman stick figures */
       /* Replace this with your actual image or use a different placeholder */
       width: 200px;
       height: 200px;
@@ -41,7 +41,7 @@
     <input type="text" id="chosenWordInput"><br>
 
     <label for="wordLength">Word Length (for random generation):</label>
-    <input type="number" id="wordLength" min="1" max="20" value="5"><br>
+    <input type="number" id="wordLength" min="2" max="15" value="5"><br>
 
     <button id="startButton">Start Game</button>
   </div>
@@ -58,7 +58,7 @@
       <label for="guessedLetters">Guessed Letters:</label>
       <span id="guessedLetters"></span>
       <br>
-      <label for"guessedWords">Guessed Words:</label>
+      <label for="guessedWords">Guessed Words:</label>
       <span id="guessedWords"></span>
     </div>
     <div id="guessInputs">
@@ -66,7 +66,7 @@
       <input type="text" id="guessLetterInput" maxlength="1">
       <button id="letterGuessButton">Guess</button>
       <br>
-      <label for="guessWordInput">Guess the whole word/phrase:</label>
+      <label for="guessWordInput">Guess the whole word:</label>
       <input type="text" id="guessWordInput">
       <button id="wordGuessButton">Guess Whole Word</button>
     </div>
@@ -93,6 +93,11 @@
     async function makeWord() {
       const customWord = $("#chosenWordInput").val().toLowerCase().trim();
       if (customWord) {
+        if (!/^[a-z]+$/.test(customWord)) {
+		      restartGame();
+			    $("#errorMessage").html('Please use only letters.');
+			    return;
+		  }
         return customWord;
       }
       const wordLength = parseInt($("#wordLength").val());
@@ -152,7 +157,11 @@
       const guess = $("#guessLetterInput").val().toLowerCase();
       $("#guessLetterInput").val("");
       $("#guessLetterInput").focus();
-      if (!guess) return;
+      if (!guess) {
+        $("#errorMessage").html('Please enter a letter.’);
+       return;
+      }
+
 
       if (!/[a-z]/.test(guess)) {
         $("#errorMessage").html('Please enter a letter.');
@@ -232,7 +241,7 @@
       const hangmanImage = $("#hangmanImage");
       if (isWin) {
         hangmanImage.css("background-color", 'green');
-        $("#guessesRemaining").html(`<string>You win!</strong><br>Score: ${gameState.remainingGuesses}`);
+        $("#guessesRemaining").html(`<strong>You win!</strong><br>Score: ${gameState.remainingGuesses}`);
       } else {
         hangmanImage.css("background-color", 'red');
         $("#guessesRemaining").html("<strong>You lose!</strong><br>");
@@ -242,8 +251,8 @@
       const guessedLetters = $("#wordDisplay").html().trim().split(' ');
       for (let i = 0; i < gameState.chosenWord.length; i++) {
         if (guessedLetters[i] === '_') {
-          const fix = `<span class="unguessed">${gameState.chosenWord[i]}</span>`;
-          guessedLetters[i] = fix;
+          const unguessedLetter = `<span class="unguessed">${gameState.chosenWord[i]}</span>`;
+          guessedLetters[i] = unguessedLetter;
         }
       }
       $("#wordDisplay").html(guessedLetters.join(' '));


### PR DESCRIPTION
Changed word generation length range from 1-20 to 2-15, because the API returns an empty string for 1 or for values over 15, which breaks the game. Fixed HTML syntax error by adding missing = sign.
Removed references to "phrase" because neither the API-generated words nor the custom input words support multi-word phrases. Added error checking to make sure the custom word consists only of letters (previously you could enter spaces, numbers, or punctuation, and the game would be unwinnable because the guess functions don't allow those inputs). Added error checking for empty letter guess input. Corrected HTML &lt;string&gt; to &lt;strong&gt;.
Changed uninformative variable name "fix" to "unguessedLetter". Capitalised "Hangman".