### PR TITLE
Fixed bug in alarm validity check

### DIFF
--- a/alarm/alarm.js
+++ b/alarm/alarm.js
@@ -74,6 +74,6 @@ function activateAlarm() {
 document.addEventListener("DOMContentLoaded", resetAlarmForm);
 alarmForm = document.forms['alarmForm']
 alarmForm.addEventListener('submit', addAlarm);
-alarmForm.addEventListener('change', checkAlarmValidity);
+alarmForm.addEventListener('focusout', checkAlarmValidity);
 
 document.getElementById("cancelBtn").addEventListener('click', cancelAlarm);


### PR DESCRIPTION
Changing the event trigger for checkAlarmValidity from "change" to "focusout". Before, it was unusable because whenever you try to enter a multi-digit number (e.g. for minutes) it would trigger as soon as you entered the first digit (e.g. 5) and then, if the current time is, say, 10 minutes past the hour, return an error because "05" is less than "10" (and then have the same problem again when you try to enter the second digit). Now, it doesn't trigger until you finish typing in the whole number.